### PR TITLE
Add react hook useTranslate

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ or with React Hooks:
 import React from 'react';
 import { useTranslate } from 'react-polyglot';
 
-export default const Greeter = ({ name }) => (
+export default const Greeter = ({ name }) => {
   const t = useTranslate();
 
   return (
     <h3>{t('hello_name', { name })}</h3>
   );
-);
+};
 
 Greeter.propTypes = {
   name: React.PropTypes.string.isRequired

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ or with React Hooks:
 import React from 'react';
 import { useTranslate } from 'react-polyglot';
 
-export default const Greeter = ({ name, t }) => (
+export default const Greeter = ({ name }) => (
   const t = useTranslate();
 
-  <h3>{t('hello_name', { name })}</h3>
+  return (
+    <h3>{t('hello_name', { name })}</h3>
+  );
 );
 
 Greeter.propTypes = {

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ npm install --save react-polyglot
 
 ## Usage
 
-`react-polyglot` exports consists for one wrapper component called `I18n` and one decorator called
-`translate`. The decorator provides a prop `t` which is instance of `Polyglot`.
+`react-polyglot` exports consists for one wrapper component called `I18n`, one decorator called
+`translate` and one hook called `useTranslate`. The decorator provides a prop `t` which is instance of `Polyglot`.
 
 You are required to wrap your root component with `I18n` and pass on a `locale` like `en` or `fr`.
 And `messages` object containing the strings.
@@ -58,6 +58,26 @@ Greeter.propTypes = {
 
 export default translate()(Greeter);
 ```
+
+
+or with React Hooks:
+
+```js
+import React from 'react';
+import { useTranslate } from 'react-polyglot';
+
+export default const Greeter = ({ name, t }) => (
+  const t = useTranslate();
+
+  <h3>{t('hello_name', { name })}</h3>
+);
+
+Greeter.propTypes = {
+  name: React.PropTypes.string.isRequired
+};
+
+```
+
 
 ## Live Examples
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
 export { default as I18n } from './i18n';
 export { default as translate } from './translate';
+export { default as useTranslate} from './useTranslate';
 export * from './translate';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import I18n from './i18n'
 import translate from './translate'
+import useTranslate from './useTranslate'
 
-export { I18n, translate }
+export { I18n, translate, useTranslate }

--- a/src/useTranslate.d.ts
+++ b/src/useTranslate.d.ts
@@ -1,0 +1,10 @@
+import { InterpolationOptions } from 'node-polyglot'
+
+type TranslateFunction = (
+    phrase: string,
+    options?: number| InterpolationOptions
+) => string
+
+declare const useTranslate = () => TranslateFunction
+
+export default useTranslate

--- a/src/useTranslate.js
+++ b/src/useTranslate.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import I18nContext from './i18n-context'
+
+export default function useTranslate() {
+  return useContext(I18nContext)
+}


### PR DESCRIPTION
Since react-polyglot does not export the l18n context to support react hooks I created a simple hook `useTranslate` that just calls useContext with l18n context.