### PR TITLE
New: Add new props for polyglot options

### DIFF
--- a/src/i18n.d.ts
+++ b/src/i18n.d.ts
@@ -3,12 +3,44 @@
 
 import { ComponentType, ReactNode } from 'react'
 
-interface I18nProps {
-  children: ReactNode
+interface InterpolationOptions {
+    smart_count?: number | { length: number };
+    _?: string;
+    [interpolationKey: string]: any;
+}
+
+interface InterpolationTokenOptions {
+  prefix?: string;
+  suffix?: string;
+}
+
+interface PluralRules {
+    pluralTypes: {
+        [key: string]: (no: number) => number;
+    };
+    pluralTypeToLanguages: {
+        [key: string]: string[];
+    };
+}
+
+interface PolyglotOptions {
   /** Locale to use, e.g. `en` */
-  locale: number
+  locale: string;
   /** A dictionary of translations */
-  messages: object
+  messages: object;
+
+  /** A boolean to control whether missing keys are allowed **/
+  allowMissing?: boolean;
+  /** If allow missing is true this function will be called instead of default error handler **/
+  onMissingKey?: (key: string, options?: InterpolationOptions, locale?: string) => string;
+  /** An object to change the substituation syntax for interpolation by setting prefix and suffix **/
+  interpolation?: InterpolationTokenOptions;
+  /** https://github.com/airbnb/polyglot.js#custom-pluralization-rules */
+  pluralRules?: PluralRules;
+}
+
+interface I18nProps extends PolyglotOptions {
+  children: ReactNode;
 }
 
 /** Provider component to wrap your root application component in. */

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,16 +11,21 @@ export default class I18n extends React.Component {
     this._polyglot = new Polyglot({
       locale: props.locale,
       phrases: props.messages,
+
+      allowMissing: props.allowMissing,
+      onMissingKey: props.onMissingKey,
+      interpolation: props.interpolation,
+      pluralRules: props.pluralRules,
     })
   }
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.locale !== this.props.locale) {
-      this._polyglot.locale(newProps.locale)
+  componentDidUpdate(prevProps) {
+    if (prevProps.locale !== this.props.locale) {
+      this._polyglot.locale(this.props.locale)
     }
 
-    if (newProps.messages !== this.props.messages) {
-      this._polyglot.replace(newProps.messages)
+    if (prevProps.messages !== this.props.messages) {
+      this._polyglot.replace(this.props.messages)
     }
   }
 
@@ -38,5 +43,24 @@ export default class I18n extends React.Component {
 I18n.propTypes = {
   locale: PropTypes.string.isRequired,
   messages: PropTypes.object.isRequired,
+
+  allowMissing: PropTypes.bool,
+  onMissingKey: PropTypes.func,
+  interpolation: PropTypes.shape({
+    suffix: PropTypes.string,
+    prefix: PropTypes.string,
+  }),
+  pluralRules: PropTypes.shape({
+    pluralTypes: PropTypes.object,
+    pluralTypeToLanguages: PropTypes.object,
+  }),
+
   children: PropTypes.element.isRequired,
+}
+
+I18n.defaultProps = {
+  allowMissing: false,
+  onMissingKey: undefined,
+  interpolation: undefined,
+  pluralRules: undefined,
 }

--- a/src/i18n.test.js
+++ b/src/i18n.test.js
@@ -30,12 +30,18 @@ describe('I18n Provider', () => {
 
     const instance = renderer.root.instance
 
-    instance.componentWillReceiveProps({
+    const newProps = {
       locale: 'jp',
       messages: {
-        test: 'Testo',
+        test: 'test',
       },
-    })
+    }
+
+    renderer.update(
+      <I18n {...newProps}>
+        <Child />
+      </I18n>
+    )
 
     expect(instance._polyglot.locale()).toBe('jp')
   })


### PR DESCRIPTION
 This commits adds new props for the following polylgot options:
   - allowMissing
   - onMissingKey
   - interpolation

 It also removes the use of componentWillReceiveProps() since it has
 been deprecated and replaces it with componentDidUpdate().