### PR TITLE
Improve typing file to be more accurate when using HOC

### DIFF
--- a/src/i18n.d.ts
+++ b/src/i18n.d.ts
@@ -6,7 +6,7 @@ import { ComponentType, ReactNode } from 'react'
 interface I18nProps {
   children: ReactNode
   /** Locale to use, e.g. `en` */
-  locale: number
+  locale: number | string
   /** A dictionary of translations */
   messages: object
 }

--- a/src/translate.d.ts
+++ b/src/translate.d.ts
@@ -2,7 +2,38 @@
 // Typescript version: 2.8
 
 import { InterpolationOptions } from 'node-polyglot'
-import { ComponentType } from 'react'
+import { ComponentType, ComponentClass } from 'react'
+
+import hoistNonReactStatics = require('hoist-non-react-statics');
+
+// Borrowed from @types/react-redux
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-redux/index.d.ts
+export type Matching<InjectedProps, DecorationTargetProps> = {
+    [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+    ? InjectedProps[P] extends DecorationTargetProps[P]
+        ? DecorationTargetProps[P]
+        : InjectedProps[P]
+    : DecorationTargetProps[P];
+};
+export type Shared<
+InjectedProps,
+DecorationTargetProps
+> = {
+    [P in Extract<keyof InjectedProps, keyof DecorationTargetProps>]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never;
+};
+export type GetProps<C> = C extends ComponentType<infer P> ? P : never;
+export type ConnectedComponentClass<
+    C extends ComponentType<any>,
+    P
+> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & hoistNonReactStatics.NonReactStatics<C> & {
+    WrappedComponent: C;
+};
+export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> =
+    <C extends ComponentType<Matching<TInjectedProps, GetProps<C>>>>(
+        component: C
+    ) => ConnectedComponentClass<C, Omit<GetProps<C>, keyof Shared<TInjectedProps, GetProps<C>>> & TNeedsProps>;
+export type InferableComponentEnhancer<TInjectedProps> =
+        InferableComponentEnhancerWithProps<TInjectedProps, {}>;
 
 export type t = (
   /** The key of the phrase to translate. */
@@ -17,8 +48,10 @@ export interface TranslateProps {
 }
 
 /** Wrap your components with `translate` to get a prop `t` passed in. */
-declare const translate = () => <T extends object>(
-  Component: ComponentType<T>
-) => ComponentType<T & TranslateProps>(Component)
+interface Translate {
+    (): InferableComponentEnhancer<TranslateProps>
+}
+
+declare const translate: Translate
 
 export default translate


### PR DESCRIPTION
Current the types remove some of the props typings when using the HOC. For example I have components that return functions instead of elements. Since children is not part of the Prop type it did not get copied over. Same thing will happen with static types as well.

I copied the types that react-redux is using which seem to work better. We could also add some tests but would need typescript installed in the repo.