### PR TITLE
Api modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ Tests and Contributing guides are in progress.
 * 0.2.4 Add a section on 'How to provide context in tests' [PR#10](https://github.com/nayaabkhan/react-polyglot/pull/10)
 * 0.2.5 Prevent creation of multiple instances on receiving new props [PR#9](https://github.com/nayaabkhan/react-polyglot/pull/9)
 * 0.2.6 Add React v16 as a peer dependency [PR#12](https://github.com/nayaabkhan/react-polyglot/pull/12)
+* 0.3.0 Removed `componentWillReceiveProps` in I18n. Change `translate` api to `translate()(Component)`.

--- a/example/app.js
+++ b/example/app.js
@@ -1,17 +1,34 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { I18n } from '../lib';
-import Greeter from './greeter';
+import React, { Fragment, useState } from 'react'
+import { render } from 'react-dom'
+import { I18n } from '../lib'
+import Greeter from './greeter'
 
-const locale = window.locale || 'en';
 const messages = {
-  "hello_name": "Hello, %{name}.",
-  "num_cars": "%{smart_count} car |||| %{smart_count} cars",
+  en: {
+    hello_name: 'Hello, %{name}.',
+    num_cars:
+      'Nice %{smart_count} car! |||| What are you doing with %{smart_count} cars?',
+  },
+
+  nl: {
+    hello_name: 'Hallo, %{name}.',
+    num_cars:
+      "Mooie %{smart_count} auto! |||| Wat moet je met %{smart_count} auto's?",
+  },
 }
 
-render(
-  <I18n locale={locale} messages={messages}>
-    <Greeter name="Batsy" />
-  </I18n>,
-  document.getElementById('app')
-);
+const App = () => {
+  const [locale, setLocale] = useState('en')
+  const toggleLocale = () => setLocale(locale === 'en' ? 'nl' : 'en')
+
+  return (
+    <Fragment>
+      <button onClick={toggleLocale}>{locale}</button>
+      <I18n locale={locale} messages={messages[locale]}>
+        <Greeter name="Batsy" nrCars={3} />
+      </I18n>
+    </Fragment>
+  )
+}
+
+render(<App />, document.getElementById('app'))

--- a/example/greeter.js
+++ b/example/greeter.js
@@ -12,7 +12,7 @@ const Greeter = ({ name, nrCars, t }) => (
 Greeter.propTypes = {
   name: PropTypes.string.isRequired,
   nrCars: PropTypes.number.isRequired,
-  t: PropTypes.func
+  t: PropTypes.func,
 }
 
 export default translate()(Greeter)

--- a/example/greeter.js
+++ b/example/greeter.js
@@ -1,8 +1,18 @@
-import React from 'react';
-import { translate } from '../lib';
+import React from 'react'
+import PropTypes from 'prop-types'
+import { translate } from '../lib'
 
-const Greeter = ({ name, t }) => (
-  <h3>{t('hello_name', { name })}</h3>
-);
+const Greeter = ({ name, nrCars, t }) => (
+  <div>
+    <h3>{t('hello_name', { name })}</h3>
+    <p>{t('num_cars', { smart_count: nrCars })}</p>
+  </div>
+)
 
-export default translate()(Greeter);
+Greeter.propTypes = {
+  name: PropTypes.string.isRequired,
+  nrCars: PropTypes.number.isRequired,
+  t: PropTypes.func
+}
+
+export default translate()(Greeter)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf lib",
     "build:example": "webpack example/app.js example/dist.js",
     "build:commonjs": "babel src --out-dir lib --ignore '*.test.js'",
-    "build": "npm run build:commonjs",
+    "build": "npm run build:commonjs && npm run build:example",
     "prepublish": "npm run clean && npm run build",
     "prettify": "prettier 'src/**/*.js' --write",
     "lint": "eslint src",
@@ -52,16 +52,16 @@
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "jest": "^22.4.3",
-    "node-polyglot": "^2.2.2",
-    "prettier": "1.12.1",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
-    "react-test-renderer": "^16.3.2",
+    "node-polyglot": "^2.3.1",
+    "prettier": "1.18.2",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
+    "react-test-renderer": "^16.9.0",
     "rimraf": "^2.5.4",
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^2.5.0",
-    "prop-types": "^15.5.8"
+    "hoist-non-react-statics": "^3.3.0",
+    "prop-types": "^15.7.2"
   }
 }

--- a/src/i18n.d.ts
+++ b/src/i18n.d.ts
@@ -5,6 +5,8 @@ import { ComponentType, ReactNode } from 'react'
 
 interface I18nProps {
   children: ReactNode
+  /** Reinitializes polyglot on every parent render. Useful when changing messages, but not locale */
+  forceReInit: boolean
   /** Locale to use, e.g. `en` */
   locale: number
   /** A dictionary of translations */

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Polyglot from 'node-polyglot'
 import I18nContext from './i18n-context'
 
 // Provider root component
-export default class I18n extends React.Component {
+export default class I18n extends Component {
   constructor(props) {
     super(props)
 
@@ -14,18 +14,13 @@ export default class I18n extends React.Component {
     })
   }
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.locale !== this.props.locale) {
-      this._polyglot.locale(newProps.locale)
-    }
-
-    if (newProps.messages !== this.props.messages) {
-      this._polyglot.replace(newProps.messages)
-    }
-  }
-
   render() {
-    const { children } = this.props
+    const { forceReInit, locale, messages, children } = this.props
+
+    if (forceReInit || this._polyglot.locale() !== locale) {
+      this._polyglot.locale(locale)
+      this._polyglot.replace(messages)
+    }
 
     return (
       <I18nContext.Provider value={this._polyglot.t.bind(this._polyglot)}>
@@ -36,7 +31,12 @@ export default class I18n extends React.Component {
 }
 
 I18n.propTypes = {
+  forceReInit: PropTypes.bool,
   locale: PropTypes.string.isRequired,
   messages: PropTypes.object.isRequired,
   children: PropTypes.element.isRequired,
+}
+
+I18n.defaultProps = {
+  forceReInit: false,
 }

--- a/src/i18n.test.js
+++ b/src/i18n.test.js
@@ -1,18 +1,9 @@
-import React, { Component } from 'react'
+import React from 'react'
 import TestRenderer from 'react-test-renderer'
 import I18n from './i18n'
 
 describe('I18n Provider', () => {
-  const createChild = () => {
-    class Child extends Component {
-      render() {
-        return <div />
-      }
-    }
-
-    return Child
-  }
-  const Child = createChild()
+  const Child = () => <div />
 
   const props = {
     locale: 'en',
@@ -28,15 +19,20 @@ describe('I18n Provider', () => {
       </I18n>
     )
 
-    const instance = renderer.root.instance
-
-    instance.componentWillReceiveProps({
+    const newProps = {
       locale: 'jp',
       messages: {
         test: 'Testo',
       },
-    })
+    }
 
+    renderer.update(
+      <I18n {...newProps}>
+        <Child />
+      </I18n>
+    )
+
+    const instance = renderer.getInstance()
     expect(instance._polyglot.locale()).toBe('jp')
   })
 })

--- a/src/translate.d.ts
+++ b/src/translate.d.ts
@@ -17,7 +17,7 @@ export interface TranslateProps {
 }
 
 /** Wrap your components with `translate` to get a prop `t` passed in. */
-declare const translate = () => <T extends object>(
+declare const translate = <T extends object>(
   Component: ComponentType<T>
 ) => ComponentType<T & TranslateProps>(Component)
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -2,15 +2,12 @@ import React from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import I18nContext from './i18n-context'
 
-// higher order decorator for components that need `t`
-export default function translate() {
-  return WrappedComponent => {
-    const _translate = props => (
-      <I18nContext.Consumer>
-        {t => <WrappedComponent {...props} t={t} />}
-      </I18nContext.Consumer>
-    )
+export default function translate()(WrappedComponent) {
+  const _translate = props => (
+    <I18nContext.Consumer>
+      {t => <WrappedComponent {...props} t={t} />}
+    </I18nContext.Consumer>
+  )
 
-    return hoistNonReactStatics(_translate, WrappedComponent)
-  }
+  return hoistNonReactStatics(_translate, WrappedComponent)
 }

--- a/src/translate.js
+++ b/src/translate.js
@@ -2,12 +2,15 @@ import React from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import I18nContext from './i18n-context'
 
-export default function translate()(WrappedComponent) {
-  const _translate = props => (
-    <I18nContext.Consumer>
-      {t => <WrappedComponent {...props} t={t} />}
-    </I18nContext.Consumer>
-  )
+// higher order decorator for components that need `t`
+export default function translate() {
+  return WrappedComponent => {
+    const _translate = props => (
+      <I18nContext.Consumer>
+        {t => <WrappedComponent {...props} t={t} />}
+      </I18nContext.Consumer>
+    )
 
-  return hoistNonReactStatics(_translate, WrappedComponent)
+    return hoistNonReactStatics(_translate, WrappedComponent)
+  }
 }

--- a/src/translate.test.js
+++ b/src/translate.test.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import TestRenderer from 'react-test-renderer'
+
+import I18n from './i18n'
+import translate from './translate'
+
+// eslint-disable-next-line
+const Consumer = ({ n, t }) => <div>{`${t('test')} ${n}`}</div>
+const Child = translate()(Consumer)
+
+const createRenderer = () =>
+  TestRenderer.create(
+    <I18n locale="en" messages={{ test: 'test' }}>
+      <Child n="123" />
+    </I18n>
+  )
+
+const updateRenderer = (
+  renderer,
+  { locale = 'en', messages, forceReInit = false }
+) => {
+  renderer.update(
+    <I18n locale={locale} messages={messages} forceReInit={forceReInit}>
+      <Child n="123" />
+    </I18n>
+  )
+}
+
+describe('translate', () => {
+  it('should update text when locale changes', () => {
+    const renderer = createRenderer()
+    expect(renderer.toJSON().children[0]).toEqual('test 123')
+
+    updateRenderer(renderer, { locale: 'jp', messages: { test: 'testo' } })
+    expect(renderer.toJSON().children[0]).toEqual('testo 123')
+  })
+
+  it('should not update text when only message changes', () => {
+    const renderer = createRenderer()
+    updateRenderer(renderer, { messages: { test: 'testing' } })
+
+    expect(renderer.toJSON().children[0]).toEqual('test 123')
+  })
+
+  it('should update text when message changes and forceReInit is true', () => {
+    const renderer = createRenderer()
+    updateRenderer(renderer, {
+      messages: { test: 'testing' },
+      forceReInit: true,
+    })
+
+    expect(renderer.toJSON().children[0]).toEqual('testing 123')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,11 +1870,12 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-for-each@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
-    is-function "~1.0.0"
+    is-callable "^1.1.3"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -2095,6 +2096,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -2108,9 +2116,12 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2345,10 +2356,6 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-function@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -2816,6 +2823,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -3003,6 +3015,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^4.0.1:
   version "4.1.2"
@@ -3241,14 +3260,15 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-polyglot@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.2.2.tgz#1a3f76d7392f836ea0823836ede817e6ea6ec26c"
+node-polyglot@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.3.1.tgz#975e8ae4cd2c717c3aac50aebc1700655d1b0b1c"
+  integrity sha512-5BWNWXiY+JHFz3DtAOhEhtwbsyr8/qgq2QmlKQYeaugm+hkqSbCpzcjn+cZ2SIqFkGVGkFAPpNQdQLms5ADNcQ==
   dependencies:
-    for-each "^0.3.2"
-    has "^1.0.1"
+    for-each "^0.3.3"
+    has "^1.0.3"
     string.prototype.trim "^1.1.2"
-    warning "^3.0.0"
+    warning "^4.0.3"
 
 node-pre-gyp@^0.9.0:
   version "0.9.1"
@@ -3571,9 +3591,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^22.4.3:
   version "22.4.3"
@@ -3604,13 +3625,22 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.6.2, prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -3660,36 +3690,39 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.3.2:
-  version "16.3.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.3.tgz#af4c2aef9f6a66251a46da50253c860a67ae66d9"
+react-dom@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
+  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.15.0"
 
-react-is@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-test-renderer@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+react-test-renderer@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"
+  integrity sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==
   dependencies:
-    fbjs "^0.8.16"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
-    react-is "^16.3.2"
+    prop-types "^15.6.2"
+    react-is "^16.9.0"
+    scheduler "^0.15.0"
 
-react@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+react@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3958,6 +3991,14 @@ sane@^2.0.0:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+scheduler@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
+  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
@@ -4535,9 +4576,10 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Hi @nayaabkhan,

Here's a PR that does the following:

- Removed componentWillReceiveProps so it's future proof. Kept the class layout in favour to function/hook layout, so polyglot can still be bound to the instance.
- Moved the `this._polyglot` calls inside an if, assuming `messages` will only need to change when `locale` changes. This is a bit more efficient.
- Introduced new prop `forceReInit` that negates above check (mimicks old default behaviour)
- More tests

The second commit is a personal thing, but I think it's neater. Instead of calling `translate()(Component)` you can now just call `translate(Component)`. There's no initialisation going on in I18n anyway.

It's a breaking change, so I can remove it from this PR if you don't like it.
