### PR TITLE
Revert back to using `componentWillReceiveProps`

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -19,13 +19,13 @@ export default class I18n extends React.Component {
     })
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.locale !== this.props.locale) {
-      this._polyglot.locale(this.props.locale)
+  componentWillReceiveProps(newProps) {
+    if (newProps.locale !== this.props.locale) {
+      this._polyglot.locale(newProps.locale)
     }
 
-    if (prevProps.messages !== this.props.messages) {
-      this._polyglot.replace(this.props.messages)
+    if (newProps.messages !== this.props.messages) {
+      this._polyglot.replace(newProps.messages)
     }
   }
 


### PR DESCRIPTION
Replacing `componentWillReceiveProps` with `componentDidUpdate`
causes the instance to be not updated before the render.